### PR TITLE
Set "to" be current date if it's missing

### DIFF
--- a/R/cranlogs.R
+++ b/R/cranlogs.R
@@ -61,6 +61,11 @@ cran_downloads <- function(packages = NULL,
   if (!missing(when)) {
     interval <- match.arg(when)
   } else {
+  
+    if(missing(to)){
+      to=Sys.Date()
+    }
+  
     if (from == to) {
       interval <- from
     } else {


### PR DESCRIPTION
Added a IF check to see if the "to" argument is missing (while "from" is given). If it's missing, then "to" will be set to the current date by default.

I guess this is a quite common demand as we always want to know the situation "until now". This also makes this function more "robust".