### PR TITLE
Updated documentation replacing 'last_' with 'last-'

### DIFF
--- a/R/cranlogs.R
+++ b/R/cranlogs.R
@@ -142,7 +142,7 @@ fill_in_dates <- function(df, start, end) {
 
 #' Top downloaded packages from the RStudio CRAN mirror
 #'
-#' @param when \code{last_day}, \code{last_week} or \code{last_month}.
+#' @param when \code{last-day}, \code{last-week} or \code{last-month}.
 #' @param count Number of packages to list. Note that the DB server
 #'   lists only at most 100 packages. This number might change in the
 #'   future.

--- a/man/cran_downloads.Rd
+++ b/man/cran_downloads.Rd
@@ -13,7 +13,7 @@ or \code{NULL} for a sum of downloads for all packages.
 Alternatively, it can also be \code{"R"}, to query downloads
 of R itself. \code{"R"} cannot be mixed with packages.}
 
-\item{when}{\code{last_day}, \code{last_week} or \code{last_month}.
+\item{when}{\code{last-day}, \code{last-week} or \code{last-month}.
 If this is given, then \code{from} and \code{to} are ignored.}
 
 \item{from}{Start date, in \code{yyyy-mm-dd} format, or

--- a/man/cran_top_downloads.Rd
+++ b/man/cran_top_downloads.Rd
@@ -8,7 +8,7 @@ cran_top_downloads(when = c("last-day", "last-week", "last-month"),
   count = 10)
 }
 \arguments{
-\item{when}{\code{last_day}, \code{last_week} or \code{last_month}.}
+\item{when}{\code{last-day}, \code{last-week} or \code{last-month}.}
 
 \item{count}{Number of packages to list. Note that the DB server
 lists only at most 100 packages. This number might change in the


### PR DESCRIPTION
Updated line for argument "when" to change from last_day, last_week or last_month to last-day, last-week or last-month. Recreated documentation so change is reflected there as well.