### PR TITLE
drop row names after re-order

### DIFF
--- a/R/cranlogs.R
+++ b/R/cranlogs.R
@@ -136,6 +136,7 @@ fill_in_dates <- function(df, start, end) {
     )
     df <- rbind(df, df2)
     df <- df[order(df$date),]
+    rownames(df) <- NULL
   }
   df
 }


### PR DESCRIPTION
With current version of cranlogs:

```
> cranlogs::cran_downloads("corpus", from="2017-04-01")
100 2017-04-01     0  corpus
101 2017-04-02     0  corpus
102 2017-04-03     0  corpus
103 2017-04-04     0  corpus
104 2017-04-05     0  corpus
105 2017-04-06     0  corpus
106 2017-04-07     0  corpus
107 2017-04-08     0  corpus
108 2017-04-09     0  corpus
109 2017-04-10     0  corpus
110 2017-04-11     0  corpus
111 2017-04-12     0  corpus
112 2017-04-13     0  corpus
113 2017-04-14     0  corpus
114 2017-04-15     0  corpus
1   2017-04-16   157  corpus
2   2017-04-17   202  corpus
...
```
Note the row names.

With the proposed patch:
```
> cranlogs::cran_downloads("corpus", from="2017-04-01")
          date count package
1   2017-04-01     0  corpus
2   2017-04-02     0  corpus
3   2017-04-03     0  corpus
4   2017-04-04     0  corpus
5   2017-04-05     0  corpus
6   2017-04-06     0  corpus
7   2017-04-07     0  corpus
8   2017-04-08     0  corpus
9   2017-04-09     0  corpus
10  2017-04-10     0  corpus
11  2017-04-11     0  corpus
12  2017-04-12     0  corpus
13  2017-04-13     0  corpus
14  2017-04-14     0  corpus
15  2017-04-15     0  corpus
16  2017-04-16   157  corpus
17  2017-04-17   202  corpus
...
```